### PR TITLE
Fix/non persistent add clip behaviour across state updates

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,7 @@
 # Learn more from ready-to-use templates: https://www.gitpod.io/docs/introduction/getting-started/quickstart
 
 tasks:
-  - init: yarn install && yarn run build
+  - init: corepack enable && yarn install && yarn run build
     command: yarn run dev
 
 

--- a/src/components/library/ClipCard/ClipCard.stories.tsx
+++ b/src/components/library/ClipCard/ClipCard.stories.tsx
@@ -18,8 +18,7 @@ const clipCardProps: IClipCard = {
   title: 'Clip Title',
   description: 'Clip Description',
   timestamp: '09-09-2002',
-  attachmentsCount: 5,
-  variant: 'existing',
+  attachmentsCount: 5
 }
 
 const clipCardWithoutAttachments: IClipCard = {

--- a/src/components/library/ClipCard/ClipCard.tsx
+++ b/src/components/library/ClipCard/ClipCard.tsx
@@ -15,7 +15,6 @@ import { useToast } from "@/components/ui/use-toast";
 
 interface IClipCard {
   title?: string
-  variant?: 'existing' | 'new'
   description?: string
   timestamp?: string
   attachmentsCount?: number
@@ -44,7 +43,7 @@ function parseDateTimestamp(timestamp: string | undefined) {
   return timeString + ', ' + dateObject.toDateString()
 }
 
-const AddNewClip = () => {
+export const AddNewClip = () => {
   const textAreaRef = useRef<HTMLTextAreaElement>(null)
   const dialogCloseRef = useRef<HTMLButtonElement>(null)
   const { state } = useLocation()
@@ -114,7 +113,7 @@ const AddNewClip = () => {
     </Dialog>
   )
 }
-const ClipCard: React.FC<IClipCard> = ({ title, description, timestamp, attachmentsCount, error, isLoading, variant = 'existing', clipId }: IClipCard) => {  
+const ClipCard: React.FC<IClipCard> = ({ title, description, timestamp, attachmentsCount, error, isLoading, clipId }: IClipCard) => {  
   const textAreaRef = useRef<HTMLTextAreaElement>(null)
   const dialogCloseRef = useRef<HTMLButtonElement>(null)
   const { toast } = useToast()
@@ -138,13 +137,6 @@ const ClipCard: React.FC<IClipCard> = ({ title, description, timestamp, attachme
       })
     }
   }, [data, deleteError, deleteLoading, toast])
-  
-  if (variant === 'new') {
-    // Show add a new clip card
-    return (
-      <AddNewClip />
-    )
-  }
   
   // Show loading skeleton
   if (isLoading) {

--- a/src/components/library/ClipCard/index.ts
+++ b/src/components/library/ClipCard/index.ts
@@ -1,1 +1,1 @@
-export { ClipCard } from "./ClipCard"
+export { ClipCard, AddNewClip } from "./ClipCard"

--- a/src/pages/Overview/Overview.tsx
+++ b/src/pages/Overview/Overview.tsx
@@ -15,7 +15,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useContext, useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ACCESS_CODE_POSTGRES, ATTACHMENTS_POSTGRES, BOARDS_RELATION, CLIPS_RELATION, CLIP_CREATED_AT_POSTGRES, CLIP_TITLE_POSTGRES, QUERY_KEYS, SupabaseContext, TEXT_CONTENT_POSTGRES } from "@/context";
-import { ClipCard } from "@/components/library/ClipCard";
+import { ClipCard, AddNewClip } from "@/components/library/ClipCard";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { QRCodeCanvas } from 'qrcode.react';
@@ -69,28 +69,24 @@ const ClipsArea: React.FC<IClipsArea> = ({ accessCode }: IClipsArea) => {
     }
   }, [supabase, accessCode, refetchClips])
 
-  let clipResults = null
-  if (data?.data) {
-    clipResults = data.data.map((clipObject: Record<string, string | unknown[]>) => (
-      <div className="flex">
-        <ClipCard
-          key={clipObject?.id as string}
-          clipId={clipObject?.id as string}
-          description={clipObject?.[TEXT_CONTENT_POSTGRES] as string}
-          title={clipObject?.[CLIP_TITLE_POSTGRES] as string}
-          error={null}
-          isLoading={false}
-          timestamp={clipObject?.[CLIP_CREATED_AT_POSTGRES] as string}
-          attachmentsCount={clipObject?.[ATTACHMENTS_POSTGRES]?.length ?? 0}
-        />
-      </div>
-    ))
-  }
   return (
     <div className="flex flex-wrap gap-4 py-4 md:py-6">
       {[
-        ...clipResults ?? [],
-        <ClipCard variant="new" />
+        ...data?.data?.map((clipObject: Record<string, string | unknown[]>) => (
+          <div className="flex">
+            <ClipCard
+              key={clipObject?.id as string}
+              clipId={clipObject?.id as string}
+              description={clipObject?.[TEXT_CONTENT_POSTGRES] as string}
+              title={clipObject?.[CLIP_TITLE_POSTGRES] as string}
+              error={null}
+              isLoading={false}
+              timestamp={clipObject?.[CLIP_CREATED_AT_POSTGRES] as string}
+              attachmentsCount={clipObject?.[ATTACHMENTS_POSTGRES]?.length ?? 0}
+            />
+          </div>
+        )) ?? [],
+        <AddNewClip key="new" />
       ]}
     </div>
   )


### PR DESCRIPTION
Earlier, content being entered into AddClip dialog textarea was being erased as the component was being re-rendered after getting latest data from realtime API. Now preventing re-rendering by allowing React to track it with a static key.